### PR TITLE
Pfm mod1

### DIFF
--- a/cytoflow/operations/bleedthrough_linear.py
+++ b/cytoflow/operations/bleedthrough_linear.py
@@ -307,6 +307,9 @@ class BleedthroughLinearDiagnostic(HasStrictTraits):
                 for op in experiment.history:
                     tube_exp = op.apply(tube_exp)
                     
+                # if kwargs.get('scale') == 'log':
+                #     tube_data = np.log10(tube_exp.data[[from_channel,to_channel]]).dropna()
+                # else:
                 tube_data = tube_exp.data
 
                 plt.subplot(num_channels, 


### PR DESCRIPTION
autofluorescence.py & util_functions.py:
- i added a the ability to throw out low abundance data which was throwing off the background subtraction calculations.  in short, this bins the data _in linear space_, sorts the bins by count, and progressively "drops" bins until a threshold is reached.  Thresholds are specified as a param in the `estimate()` method (.99 == 1% of total data dropped).  Of course, this selectively drops the high-signal evens where the lin-space bins are sparsely populated.  the resulting "bins that are to be dropped" are aggregated and stored as boolean `threshold_masks` for each channel.  These masks are used during the `estimate()` method to filter the data when calculating the median/std, and again during `plot()` for better viewing.  
- The function used to bin, sort, flag, aggregate, and generate the bool masks was written separately and saved in `util_functions.py`.

bead_calibration.py:
- I changed the `bead_brightness_cutoff` parameter to be what I assumed it was _supposed_ to be... where you specify a float (0,1] and the numerical value of that cutoff is determined from the data's range.  At least, this was the case for the default value, but was not propagated for the user-specified option.  A matching change was made in the `plot()` method.
- I added a 3-parameter fit option which was intended to better fit the raw bead data.  However, it currently fails to properly identify the right peaks (occasionally) and so is not usable ATM.  
- I also added a title option to the `**kwargs` of `plot`.
- One more... I added a LOT identifier to the spherotech bead data in the class object... it's there in the documentation available online but wasn't in your copy.

bleedthrough_linear.py:
- I really wanted to plot this on a log or hyperlog scale, but couldn't.  currently my changes are all commented out.