### PR TITLE
DataFrame input for operations

### DIFF
--- a/cytoflow/operations/color_translation.py
+++ b/cytoflow/operations/color_translation.py
@@ -409,7 +409,7 @@ class ColorTranslationDiagnostic(HasStrictTraits):
 
         tubes = {}
 
-        if (self.controls != {}):
+        if (self.op.controls != {}):
             controls = self.op.controls
         else:
             controls = self.op.controls_frames

--- a/cytoflow/operations/import_op.py
+++ b/cytoflow/operations/import_op.py
@@ -306,6 +306,7 @@ class ImportOp(HasStrictTraits):
         else:
             channels = list(self.channels.keys()) if self.channels else list(self.tubes[0].frame)
             meta_channels = DataFrame()
+            experiment.metadata["name_metadata"] = None
 
         # now that we have the metadata, load it into experiment
 


### PR DESCRIPTION
This PR adds a feature to accept a pandas DataFrame as input for the Tube object, ImportOp, the autofluorescence model, the bleedthrough model, the bead calibration, and the color mapping operation.