### PR TITLE
Density view for operations on 2D plots

### DIFF
--- a/cytoflow/operations/range2d.py
+++ b/cytoflow/operations/range2d.py
@@ -389,7 +389,6 @@ if __name__ == '__main__':
     
     plt.ioff()
     rv.plot(ex)
-    rv.interactive = True
     plt.show()
     print("x:({0}, {1})  y:({2}, {3})".format(r.xlow, r.xhigh, r.ylow, r.yhigh))
 

--- a/cytoflow/tests/test_polygon.py
+++ b/cytoflow/tests/test_polygon.py
@@ -54,6 +54,7 @@ class Test(unittest.TestCase):
         
     def testPlot(self):
         self.gate.default_view().plot(self.ex)
+        self.gate.density_view(huescale="log", color="red").plot(self.ex, gridsize=20)
 
 
 if __name__ == "__main__":

--- a/cytoflow/tests/test_quad.py
+++ b/cytoflow/tests/test_quad.py
@@ -53,6 +53,7 @@ class Test(unittest.TestCase):
         
     def testPlot(self):
         self.gate.default_view().plot(self.ex)
+        self.gate.density_view(huescale="log", color="red").plot(self.ex, gridsize=20)
 
 
 if __name__ == "__main__":

--- a/cytoflow/tests/test_range2d.py
+++ b/cytoflow/tests/test_range2d.py
@@ -51,6 +51,7 @@ class Test(unittest.TestCase):
         
     def testPlot(self):
         self.gate.default_view().plot(self.ex)
+        self.gate.density_view(huescale="log", color="red").plot(self.ex, gridsize=20)
 
 
 if __name__ == "__main__":

--- a/cytoflow/utility/matplotlib_widgets.py
+++ b/cytoflow/utility/matplotlib_widgets.py
@@ -48,13 +48,14 @@ class PolygonSelector(AxesWidget):
         function is called and passed the vertices of the selected path.
     """
 
-    def __init__(self, ax, callback=None, useblit=True):
+    def __init__(self, ax, callback=None, useblit=True, color="black"):
         AxesWidget.__init__(self, ax)
 
         self.useblit = useblit and self.canvas.supports_blit
         self.verts = []
         self.drawing = False
         self.line = None
+        self.color = color
         self.callback = callback
         self.last_click_time = time.time()
         self.connect_event('button_press_event', self.onpress)
@@ -68,7 +69,7 @@ class PolygonSelector(AxesWidget):
             # start over
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
             self.verts = [(event.xdata, event.ydata)]
-            self.line = Line2D([event.xdata], [event.ydata], linestyle='-', color='black', lw=1)
+            self.line = Line2D([event.xdata], [event.ydata], linestyle='-', color=self.color, lw=1)
             self.ax.add_line(self.line)
             self.drawing = True
         else:


### PR DESCRIPTION
Hey Brian! Glad to see you're behind this awesome tool :)

For `PolygonOp`, `QuadOp`, and `Range2DOp` I've found it more useful to work with a density view, rather than a scatterplot view, so I add a new method, `density_view`, to do that. It works like `default_view`, but uses `DensityView` instead of `ScatterplotView`. 1D versions of these operations already use a histogram.

To implement it, I made a new "base" class, e.g. `PolygonSelectionBase` that does not inherit from any `View` class, and then make new very minimal classes that do inherit from `View` classes, e.g. `class PolygonSelection(PolygonSelectionBase, ScatterplotView)`, `class PolygonDensitySelection(PolygonSelectionBase, DensityView)`.

I also enable setting the color of the selection box/lines.

I've included example code in the `if __name__ == '__main__'` sections; I had to tweak these sections and some of the imports in the files a bit to get them to run.

I haven't made any GUI changes to enable using this, though, nor have I added examples of this to the notebooks (I'm thinking of adding examples in a later PR that also shows how to save figures, tweak them, etc).