### PR TITLE
If import fails due to voltage mismatch, specify channel

### DIFF
--- a/cytoflow/operations/import_op.py
+++ b/cytoflow/operations/import_op.py
@@ -496,8 +496,8 @@ def check_tube(filename, experiment, data_set = 0):
             new_v = tube_channels.loc[fcs_name]['$PnV']
             
             if old_v != new_v and not channel in ignore_v:
-                raise util.CytoflowError("Tube {0} doesn't have the same voltages"
-                                    .format(filename))
+                raise util.CytoflowError("Tube {0} doesn't have the same voltages for channel "
+                                    .format(filename) + str(channel))
 
         # TODO check the delay -- and any other params?
         


### PR DESCRIPTION
I was getting an error since an unused channel in one of my tubes had a different voltage. It was a bit of a pain to track down which channel had the issue, so I made the error message also display which channel had the mismatch.