### PR TITLE
switched from fcsparser as submodule to original fcsparser package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
 [submodule "docs/examples-advanced"]
 	path = docs/examples-advanced
 	url = https://github.com/cytoflow/cytoflow-examples.git
-
-
-[submodule "fcsparser"]
-	path = fcsparser
-	url = https://github.com/cytoflow/fcsparser.git
-	branch = cytoflow1.2

--- a/cytoflow/experiment.py
+++ b/cytoflow/experiment.py
@@ -516,7 +516,7 @@ class Experiment(HasStrictTraits):
         Examples
         --------
         >>> import cytoflow as flow
-        >>> from fcsparser import fcsparser
+        >>> import fcsparser
         >>> ex = flow.Experiment()
         >>> ex.add_condition("Time", "float")
         >>> ex.add_condition("Strain", "category")
@@ -581,7 +581,7 @@ class Experiment(HasStrictTraits):
             self.metadata[condition]['values'] = natsorted(self.data[condition].unique())
 
 if __name__ == "__main__":
-    from fcsparser import fcsparser
+    import fcsparser
     ex = Experiment()
     ex.add_conditions({"time" : "category"})
 

--- a/cytoflow/operations/import_op.py
+++ b/cytoflow/operations/import_op.py
@@ -42,7 +42,7 @@ import warnings, math
 from traits.api import (HasTraits, HasStrictTraits, provides, Str, List, Any,
                         Dict, File, Constant, Enum, Int)
 
-from fcsparser import fcsparser
+import fcsparser
 import numpy as np
 from pathlib import Path
 

--- a/cytoflow/scripts/fcs_metadata.py
+++ b/cytoflow/scripts/fcs_metadata.py
@@ -25,7 +25,7 @@ Return the FCS metadata (in key : value format) for a given FCS file.
 """
 
 import argparse
-from fcsparser import fcsparser
+import fcsparser
 
 def main():
     parser = argparse.ArgumentParser()

--- a/cytoflow/scripts/split_fcs.py
+++ b/cytoflow/scripts/split_fcs.py
@@ -28,7 +28,7 @@ files using the provided FCS metadata.
 
 import argparse, warnings, pathlib, re
 from copy import copy
-from fcsparser import fcsparser
+import fcsparser
 import cytoflow as flow
 import cytoflow.utility as util
 

--- a/cytoflowgui/flow_task.py
+++ b/cytoflowgui/flow_task.py
@@ -631,7 +631,7 @@ class FlowTask(Task):
     
     def _get_package_versions(self):    
         from cytoflow import __version__ as cf_version
-        from fcsparser.fcsparser import __version__ as fcs_version
+        from fcsparser import __version__ as fcs_version
         from pandas import __version__ as pd_version
         from numpy import __version__ as np_version
         from numexpr import __version__ as nxp_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ seaborn==0.11.2
 statsmodels==0.13.0
 natsort==7.1.1
 numba==0.53.1
-
+fcsparser==0.2.4
 traits==6.2.0
 traitsui==7.2.1
 pyface==7.3.0


### PR DESCRIPTION
Since fcsparser included the adaptation to support multi tube files (https://github.com/eyurtsev/fcsparser/commit/9ca4e32ee491f6ce2c6cb67a257c1095b5100387). It's possible to switch back using the original fcsparser package instead of a submodule.

The adaptations of this 