### PR TITLE
Fix ModuleNotFoundError for installations without the `logicle_scale` module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A few things.
 **If you just want the point-and-click version (not the Python modules), you 
   can install it from http://cytoflow.github.io/**
 
-See the [installation notes](http://cytoflow.readthedocs.org/en/stable/INSTALL.html) 
+See the [installation notes](https://cytoflow.readthedocs.io/en/stable/dev_manual/howto/install.html) 
 on [ReadTheDocs](http://cytoflow.readthedocs.org/).  Installation has been 
 testedon Linux, Windows (x86_64) and Mac (both Intel and Apple Silicon).  
 Cytoflow is distributed as an [Anaconda](https://www.anaconda.com/) package 

--- a/cytoflow/utility/scale.py
+++ b/cytoflow/utility/scale.py
@@ -35,6 +35,7 @@ Base classes and functions for `cytoflow` scales.
 """
 
 import numbers
+import logging
 
 from traits.api import Interface, Str, Instance, Tuple, Array
 
@@ -203,7 +204,11 @@ def get_default_scale():
 # register the new scales
 import cytoflow.utility.linear_scale   # @UnusedImport
 import cytoflow.utility.log_scale      # @UnusedImport
-import cytoflow.utility.logicle_scale  # @UnusedImport
+try:
+    import cytoflow.utility.logicle_scale  # @UnusedImport
+except ModuleNotFoundError:
+    logger = logging.getLogger(__name__)
+    logger.debug("ModuleNotFound: Logicle module not included in the installation.")
 
 # this scale is REALLY SLOW.  If you want it for your analysis, you can
 # import it into your script, that will register it with the global list.


### PR DESCRIPTION
The [installation instructions](https://cytoflow.readthedocs.io/en/stable/dev_manual/howto/install.html) explain how to install without the `logicle_scale` module by setting `NO_LOGICLE=True`.

The `setup.py` conditions the inclusion of the module on this environment variable: https://github.com/cytoflow/cytoflow/blob/a51dbf8093fd796fc83ba451bfae370365207f76/setup.py#L26-L35

Consequently, `import cytoflow.utility.logicle_scale` runs into a `ModuleNotFoundError`.

This PR fixes the import and a broken link in the README.

Closes #359 