### PR TITLE
perf: vectorize Mahalanobis distance in GaussianMixtureOp.apply()

### DIFF
--- a/cytoflow/operations/gaussian.py
+++ b/cytoflow/operations/gaussian.py
@@ -559,10 +559,9 @@ class GaussianMixtureOp(HasStrictTraits):
                     s = np.linalg.pinv(gmm.covariances_[c])
                     mu = gmm.means_[c]
                     
-                    # compute the Mahalanobis distance
-
-                    f = lambda x, mu, s: np.dot(np.dot((x - mu).T, s), (x - mu))
-                    dist = np.apply_along_axis(f, 1, x, mu, s)
+                    # compute the Mahalanobis distance (vectorized)
+                    diff = x - mu
+                    dist = np.sum(diff @ s * diff, axis=1)
 
                     # come up with a threshold based on sigma.  you'll note we
                     # didn't sqrt dist: that's because for a multivariate 


### PR DESCRIPTION
## Summary

Vectorize the Mahalanobis distance calculation in `GaussianMixtureOp.apply()` for a ~17x speedup on sigma-based gating.

## Problem

The current implementation computes Mahalanobis distance using a per-row Python lambda via `np.apply_along_axis`:

```python
f = lambda x, mu, s: np.dot(np.dot((x - mu).T, s), (x - mu))
dist = np.apply_along_axis(f, 1, x, mu, s)
```

This calls the lambda once per event per component. On large datasets this becomes the dominant cost of `apply()`.

## Fix

Replace with equivalent vectorized numpy operations:

```python
diff = x - mu
dist = np.sum(diff @ s * diff, axis=1)
```

Mathematically identical — verified to within `3.55e-15` floating point precision.

## Benchmarks

On a large multi-tube dataset (~4M events after gating, 2 components):

| | Before | After |
|---|---|---|
| `GaussianMixtureOp.apply()` | ~27s | ~1.6s |

## Test plan

- [x] Verify vectorized math produces identical results (`np.allclose` passes)
- [ ] Run existing test suite